### PR TITLE
Add total functionality for multiple endpoints

### DIFF
--- a/api/appsendpoint.go
+++ b/api/appsendpoint.go
@@ -5,7 +5,6 @@ import (
 	"github.com/cyverse-de/de-stats/util"
 	"github.com/labstack/echo"
 	"net/http"
-	"time"
 )
 
 type AppsParams struct {
@@ -39,20 +38,8 @@ type AppsResponse struct {
 }
 
 func AppsHandler(ctx echo.Context) error{
-	const (
-		dateFormat = "20060102"
-	)
-
-	currentTime := time.Now()
-	oneWeekAgo := time.Now().AddDate(0, 0, -7)
-
-	startDate, err := util.StringQueryParam(ctx, "startDate", oneWeekAgo.Format(dateFormat))
+	startDate, endDate, err := util.VerifyDateParameters(ctx)
 	if err != nil {
-		return ctx.JSON(http.StatusBadRequest, ErrorResponse{Description: err.Error()})
-	}
-
-	endDate, err := util.StringQueryParam(ctx, "endDate", currentTime.Format(dateFormat))
-	if err != nil{
 		return ctx.JSON(http.StatusBadRequest, ErrorResponse{Description: err.Error()})
 	}
 

--- a/api/appsendpoint.go
+++ b/api/appsendpoint.go
@@ -1,11 +1,10 @@
 package api
 
 import (
-	"fmt"
 	"github.com/cyverse-de/de-stats/cron"
+	"github.com/cyverse-de/de-stats/util"
 	"github.com/labstack/echo"
 	"net/http"
-	"github.com/cyverse-de/de-stats/util"
 	"time"
 )
 
@@ -48,23 +47,16 @@ func AppsHandler(ctx echo.Context) error{
 	oneWeekAgo := time.Now().AddDate(0, 0, -7)
 
 	startDate, err := util.StringQueryParam(ctx, "startDate", oneWeekAgo.Format(dateFormat))
-	fmt.Println(startDate)
 	if err != nil {
 		return ctx.JSON(http.StatusBadRequest, ErrorResponse{Description: err.Error()})
 	}
 
 	endDate, err := util.StringQueryParam(ctx, "endDate", currentTime.Format(dateFormat))
-	fmt.Println(endDate)
 	if err != nil{
 		return ctx.JSON(http.StatusBadRequest, ErrorResponse{Description: err.Error()})
 	}
-	eDate, err := time.Parse(dateFormat, endDate)
-	eDate.AddDate(0, 0, 1)
-	endDate = eDate.Format(dateFormat)
-
 
 	amount, err := util.IntQueryParam(ctx, "count", 10, 1, 1000)
-	fmt.Println(amount)
 	if err != nil {
 		return ctx.JSON(http.StatusBadRequest, ErrorResponse{Description: err.Error()})
 	}

--- a/api/appsendpoint.go
+++ b/api/appsendpoint.go
@@ -1,6 +1,7 @@
 package api
 
 import (
+	"database/sql"
 	"github.com/cyverse-de/de-stats/cron"
 	"github.com/cyverse-de/de-stats/util"
 	"github.com/labstack/echo"
@@ -37,28 +38,28 @@ type AppsResponse struct {
 	Apps	[]cron.App	`json:"apps"`
 }
 
-func AppsHandler(ctx echo.Context) error{
-	startDate, endDate, err := util.VerifyDateParameters(ctx)
-	if err != nil {
-		return ctx.JSON(http.StatusBadRequest, ErrorResponse{Description: err.Error()})
+func BuildAppsHandler(db *sql.DB) func(echo.Context) error {
+	return func(ctx echo.Context) error {
+		startDate, endDate, err := util.VerifyDateParameters(ctx)
+		if err != nil {
+			return ctx.JSON(http.StatusBadRequest, ErrorResponse{Description: err.Error()})
+		}
+
+		amount, err := util.IntQueryParam(ctx, "count", 10, 1, 1000)
+		if err != nil {
+			return ctx.JSON(http.StatusBadRequest, ErrorResponse{Description: err.Error()})
+		}
+
+		apps, err := cron.GetTopApps(db, amount, startDate, endDate)
+
+		if err != nil{
+			return err
+		}
+
+		resp := AppsResponse{
+			Count: len(apps),
+			Apps:  apps,
+		}
+		return ctx.JSON(http.StatusOK, resp)
 	}
-
-	amount, err := util.IntQueryParam(ctx, "count", 10, 1, 1000)
-	if err != nil {
-		return ctx.JSON(http.StatusBadRequest, ErrorResponse{Description: err.Error()})
-	}
-
-	db := cron.InitDB()
-	apps, err := cron.GetTopApps(db, amount, startDate, endDate)
-
-	if err != nil{
-		return err
-	}
-
-	resp := AppsResponse{
-		Count: len(apps),
-		Apps:  apps,
-	}
-	return ctx.JSON(http.StatusOK, resp)
-
 }

--- a/api/appsendpoint.go
+++ b/api/appsendpoint.go
@@ -6,6 +6,7 @@ import (
 	"github.com/labstack/echo"
 	"net/http"
 	"github.com/cyverse-de/de-stats/util"
+	"time"
 )
 
 type AppsParams struct {
@@ -35,12 +36,21 @@ type AppsResponse struct {
 
 func AppsHandler(ctx echo.Context) error{
 
-	days, err := util.IntQueryParam(ctx, "days", 1, 0, 365)
-	fmt.Println(days)
+	currentTime := time.Now()
+	oneWeekAgo := time.Now().AddDate(0, 0, -7)
+
+	startDate, err := util.StringQueryParam(ctx, "startDate", oneWeekAgo.Format("00/00/0000"))
+	fmt.Println(startDate)
 	if err != nil {
 		return ctx.JSON(http.StatusBadRequest, ErrorResponse{Description: err.Error()})
 	}
-	db := cron.InitDB()
+
+	endDate, err := util.StringQueryParam(ctx, "endDate", currentTime.Format("00/00/0000"))
+	fmt.Println(endDate)
+	if err != nil{
+		return ctx.JSON(http.StatusBadRequest, ErrorResponse{Description: err.Error()})
+	}
+
 
 	amount, err := util.IntQueryParam(ctx, "count", 10, 1, 1000)
 	fmt.Println(amount)
@@ -48,7 +58,8 @@ func AppsHandler(ctx echo.Context) error{
 		return ctx.JSON(http.StatusBadRequest, ErrorResponse{Description: err.Error()})
 	}
 
-	apps, err := cron.GetTopApps(db, amount, days)
+	db := cron.InitDB()
+	apps, err := cron.GetTopApps(db, amount, startDate, endDate)
 
 	if err != nil{
 		return err

--- a/api/jobsendpoint.go
+++ b/api/jobsendpoint.go
@@ -28,37 +28,15 @@ type JobsResponse struct {
 	Count int	 	`json:"count"`
 	Jobs []cron.JobStats `json:"jobs"`
 }
-func BuildJobsSubmittedHandler(db *sql.DB) func(echo.Context) error {
+
+func BuildJobsHandler(db *sql.DB) func(echo.Context) error {
 	return func(ctx echo.Context) error {
 		startDate, endDate, err := util.VerifyDateParameters(ctx)
 		if err != nil {
 			return ctx.JSON(http.StatusBadRequest, ErrorResponse{Description: err.Error()})
 		}
 
-		jobs, err := cron.GetSubmittedJobCounts(db, startDate, endDate)
-
-		if err != nil {
-			return err
-		}
-
-		count := len(jobs)
-		resp := JobsResponse{
-			Count: count,
-			Jobs:  jobs,
-		}
-
-		return ctx.JSON(http.StatusOK, resp)
-	}
-}
-
-func BuildJobsStatusHandler(db *sql.DB) func(echo.Context) error {
-	return func(ctx echo.Context) error {
-		startDate, endDate, err := util.VerifyDateParameters(ctx)
-		if err != nil {
-			return ctx.JSON(http.StatusBadRequest, ErrorResponse{Description: err.Error()})
-		}
-
-		jobs, err := cron.GetJobStatusCounts(db, startDate, endDate)
+		jobs, err := cron.GetJobCounts(db, startDate, endDate)
 
 		if err != nil {
 			return err

--- a/api/jobsendpoint.go
+++ b/api/jobsendpoint.go
@@ -1,12 +1,10 @@
 package api
 
 import (
-	"fmt"
 	"github.com/cyverse-de/de-stats/cron"
 	"github.com/cyverse-de/de-stats/util"
 	"github.com/labstack/echo"
 	"net/http"
-	"time"
 )
 
 type JobsParams struct {
@@ -30,32 +28,9 @@ type JobsResponse struct {
 	Jobs []cron.JobStats `json:"jobs"`
 }
 
-func verifyJobsParameters(ctx echo.Context) (string, string, error) {
-	const (
-		dateFormat = "20060102"
-	)
-
-	currentTime := time.Now()
-	oneWeekAgo := time.Now().AddDate(0, 0, -7)
-
-	startDate, err := util.StringQueryParam(ctx, "startDate", oneWeekAgo.Format(dateFormat))
-	fmt.Println(startDate)
-	if err != nil {
-		return "", "", ctx.JSON(http.StatusBadRequest, ErrorResponse{Description: err.Error()})
-	}
-
-	endDate, err := util.StringQueryParam(ctx, "endDate", currentTime.Format(dateFormat))
-	fmt.Println(endDate)
-	if err != nil{
-		return "", "", ctx.JSON(http.StatusBadRequest, ErrorResponse{Description: err.Error()})
-	}
-
-	return startDate, endDate, nil
-}
-
 func JobsSubmittedHandler(ctx echo.Context) error {
 
-	startDate, endDate, err := verifyJobsParameters(ctx)
+	startDate, endDate, err := util.VerifyDateParameters(ctx)
 	if err != nil {
 		return ctx.JSON(http.StatusBadRequest, ErrorResponse{Description: err.Error()})
 	}
@@ -78,7 +53,7 @@ func JobsSubmittedHandler(ctx echo.Context) error {
 }
 
 func JobsStatusHandler(ctx echo.Context) error {
-	startDate, endDate, err := verifyJobsParameters(ctx)
+	startDate, endDate, err := util.VerifyDateParameters(ctx)
 	if err != nil {
 		return ctx.JSON(http.StatusBadRequest, ErrorResponse{Description: err.Error()})
 	}

--- a/api/jobsendpoint.go
+++ b/api/jobsendpoint.go
@@ -27,7 +27,7 @@ type JobsParams struct {
 
 type JobsResponse struct {
 	Count int	 	`json:"count"`
-	Jobs []cron.Job `json:"jobs"`
+	Jobs []cron.JobStats `json:"jobs"`
 }
 
 func verifyJobsParameters(ctx echo.Context) (string, string, error) {

--- a/api/jobsendpoint.go
+++ b/api/jobsendpoint.go
@@ -1,6 +1,7 @@
 package api
 
 import (
+	"database/sql"
 	"github.com/cyverse-de/de-stats/cron"
 	"github.com/cyverse-de/de-stats/util"
 	"github.com/labstack/echo"
@@ -27,49 +28,48 @@ type JobsResponse struct {
 	Count int	 	`json:"count"`
 	Jobs []cron.JobStats `json:"jobs"`
 }
+func BuildJobsSubmittedHandler(db *sql.DB) func(echo.Context) error {
+	return func(ctx echo.Context) error {
+		startDate, endDate, err := util.VerifyDateParameters(ctx)
+		if err != nil {
+			return ctx.JSON(http.StatusBadRequest, ErrorResponse{Description: err.Error()})
+		}
 
-func JobsSubmittedHandler(ctx echo.Context) error {
+		jobs, err := cron.GetSubmittedJobCounts(db, startDate, endDate)
 
-	startDate, endDate, err := util.VerifyDateParameters(ctx)
-	if err != nil {
-		return ctx.JSON(http.StatusBadRequest, ErrorResponse{Description: err.Error()})
+		if err != nil {
+			return err
+		}
+
+		count := len(jobs)
+		resp := JobsResponse{
+			Count: count,
+			Jobs:  jobs,
+		}
+
+		return ctx.JSON(http.StatusOK, resp)
 	}
-
-	db := cron.InitDB()
-	jobs, err := cron.GetSubmittedJobCounts(db, startDate, endDate)
-	
-	if err != nil {
-		return err
-	}
-
-	count := len(jobs)
-	resp := JobsResponse{
-		Count: count,
-		Jobs:  jobs,
-	}
-
-	return ctx.JSON(http.StatusOK, resp)
-
 }
 
-func JobsStatusHandler(ctx echo.Context) error {
-	startDate, endDate, err := util.VerifyDateParameters(ctx)
-	if err != nil {
-		return ctx.JSON(http.StatusBadRequest, ErrorResponse{Description: err.Error()})
+func BuildJobsStatusHandler(db *sql.DB) func(echo.Context) error {
+	return func(ctx echo.Context) error {
+		startDate, endDate, err := util.VerifyDateParameters(ctx)
+		if err != nil {
+			return ctx.JSON(http.StatusBadRequest, ErrorResponse{Description: err.Error()})
+		}
+
+		jobs, err := cron.GetJobStatusCounts(db, startDate, endDate)
+
+		if err != nil {
+			return err
+		}
+
+		count := len(jobs)
+		resp := JobsResponse{
+			Count: count,
+			Jobs:  jobs,
+		}
+
+		return ctx.JSON(http.StatusOK, resp)
 	}
-
-	db := cron.InitDB()
-	jobs, err := cron.GetJobStatusCounts(db, startDate, endDate)
-
-	if err != nil {
-		return err
-	}
-
-	count := len(jobs)
-	resp := JobsResponse{
-		Count: count,
-		Jobs:  jobs,
-	}
-
-	return ctx.JSON(http.StatusOK, resp)
 }

--- a/api/jobsendpoint.go
+++ b/api/jobsendpoint.go
@@ -1,0 +1,68 @@
+package api
+
+import (
+	"fmt"
+	"github.com/cyverse-de/de-stats/cron"
+	"github.com/cyverse-de/de-stats/util"
+	"github.com/labstack/echo"
+	"net/http"
+	"time"
+)
+
+type JobsParams struct {
+	//The beginning of the time period of the response
+	//
+	//in: query
+	//required: false
+	//default: one week ago
+	StartDate string
+
+	//The end of the time period of the response
+	//
+	//in: query
+	//required: false
+	//default: today
+	EndDate string
+}
+
+type JobsResponse struct {
+	Count int	 	`json:"count"`
+	Jobs []cron.Job `json:"jobs"`
+}
+
+func JobsSubmittedHandler(ctx echo.Context) error {
+	const (
+		dateFormat = "2006-01-02"
+	)
+
+	currentTime := time.Now()
+	oneWeekAgo := time.Now().AddDate(0, 0, -7)
+
+	startDate, err := util.StringQueryParam(ctx, "startDate", oneWeekAgo.Format(dateFormat))
+	fmt.Println(startDate)
+	if err != nil {
+		return ctx.JSON(http.StatusBadRequest, ErrorResponse{Description: err.Error()})
+	}
+
+	endDate, err := util.StringQueryParam(ctx, "endDate", currentTime.Format(dateFormat))
+	fmt.Println(endDate)
+	if err != nil{
+		return ctx.JSON(http.StatusBadRequest, ErrorResponse{Description: err.Error()})
+	}
+
+	db := cron.InitDB()
+	jobs, err = cron.getSubmittedJobCounts(db, startDate, endDate)
+	
+	if err != nil {
+		return err
+	}
+
+	count := len(jobs)
+	resp := JobsResponse{
+		Count: count,
+		Jobs:  jobs,
+	}
+
+	return ctx.JSON(http.StatusOK, resp)
+
+}

--- a/api/jobsendpoint.go
+++ b/api/jobsendpoint.go
@@ -51,7 +51,7 @@ func JobsSubmittedHandler(ctx echo.Context) error {
 	}
 
 	db := cron.InitDB()
-	jobs, err = cron.getSubmittedJobCounts(db, startDate, endDate)
+	jobs, err := cron.GetSubmittedJobCounts(db, startDate, endDate)
 	
 	if err != nil {
 		return err

--- a/api/loginsendpoint.go
+++ b/api/loginsendpoint.go
@@ -1,0 +1,95 @@
+package api
+
+import (
+	"fmt"
+	"github.com/cyverse-de/de-stats/cron"
+	"github.com/cyverse-de/de-stats/util"
+	"github.com/labstack/echo"
+	"net/http"
+	"time"
+)
+
+type LoginsParams struct {
+	//The beginning of the time period of the response
+	//
+	//in: query
+	//required: false
+	//default: one week ago
+	StartDate string
+
+	//The end of the time period of the response
+	//
+	//in: query
+	//required: false
+	//default: today
+	EndDate string
+}
+
+type LoginsResponse struct {
+	Count int 	`json:"count"`
+}
+
+func verifyLoginParameters(ctx echo.Context) (string, string, error) {
+	const (
+		dateFormat = "20060102"
+	)
+
+	currentTime := time.Now()
+	oneWeekAgo := time.Now().AddDate(0, 0, -7)
+
+	startDate, err := util.StringQueryParam(ctx, "startDate", oneWeekAgo.Format(dateFormat))
+	fmt.Println(startDate)
+	if err != nil {
+		return "", "", ctx.JSON(http.StatusBadRequest, ErrorResponse{Description: err.Error()})
+	}
+
+	endDate, err := util.StringQueryParam(ctx, "endDate", currentTime.Format(dateFormat))
+	fmt.Println(endDate)
+	if err != nil{
+		return "", "", ctx.JSON(http.StatusBadRequest, ErrorResponse{Description: err.Error()})
+	}
+
+	return startDate, endDate, nil
+}
+
+func DistinceLoginCountHandler(ctx echo.Context) error {
+
+	startDate, endDate, err := verifyLoginParameters(ctx)
+	if err != nil {
+		return ctx.JSON(http.StatusBadRequest, ErrorResponse{Description: err.Error()})
+	}
+
+	db := cron.InitDB()
+	login, err := cron.GetDistinctLoginCount(db, startDate, endDate)
+
+	if err != nil {
+		return err
+	}
+
+	resp := LoginsResponse{
+		Count: login.Count,
+	}
+
+	return ctx.JSON(http.StatusOK, resp)
+
+}
+
+func LoginCountHandler(ctx echo.Context) error {
+	startDate, endDate, err := verifyLoginParameters(ctx)
+	if err != nil {
+		return ctx.JSON(http.StatusBadRequest, ErrorResponse{Description: err.Error()})
+	}
+
+	db := cron.InitDB()
+	login, err := cron.GetLoginCount(db, startDate, endDate)
+
+	if err != nil {
+		return err
+	}
+
+	resp := LoginsResponse{
+		Count: login.Count,
+	}
+
+	return ctx.JSON(http.StatusOK, resp)
+}

--- a/api/loginsendpoint.go
+++ b/api/loginsendpoint.go
@@ -5,7 +5,6 @@ import (
 	"github.com/cyverse-de/de-stats/util"
 	"github.com/labstack/echo"
 	"net/http"
-	"time"
 )
 
 type LoginsParams struct {
@@ -28,30 +27,9 @@ type LoginsResponse struct {
 	Count int 	`json:"count"`
 }
 
-func verifyLoginParameters(ctx echo.Context) (string, string, error) {
-	const (
-		dateFormat = "20060102"
-	)
-
-	currentTime := time.Now()
-	oneWeekAgo := time.Now().AddDate(0, 0, -7)
-
-	startDate, err := util.StringQueryParam(ctx, "startDate", oneWeekAgo.Format(dateFormat))
-	if err != nil {
-		return "", "", ctx.JSON(http.StatusBadRequest, ErrorResponse{Description: err.Error()})
-	}
-
-	endDate, err := util.StringQueryParam(ctx, "endDate", currentTime.Format(dateFormat))
-	if err != nil{
-		return "", "", ctx.JSON(http.StatusBadRequest, ErrorResponse{Description: err.Error()})
-	}
-
-	return startDate, endDate, nil
-}
-
 func DistinctLoginCountHandler(ctx echo.Context) error {
 
-	startDate, endDate, err := verifyLoginParameters(ctx)
+	startDate, endDate, err := util.VerifyDateParameters(ctx)
 	if err != nil {
 		return ctx.JSON(http.StatusBadRequest, ErrorResponse{Description: err.Error()})
 	}
@@ -72,7 +50,7 @@ func DistinctLoginCountHandler(ctx echo.Context) error {
 }
 
 func LoginCountHandler(ctx echo.Context) error {
-	startDate, endDate, err := verifyLoginParameters(ctx)
+	startDate, endDate, err := util.VerifyDateParameters(ctx)
 	if err != nil {
 		return ctx.JSON(http.StatusBadRequest, ErrorResponse{Description: err.Error()})
 	}

--- a/api/loginsendpoint.go
+++ b/api/loginsendpoint.go
@@ -1,7 +1,6 @@
 package api
 
 import (
-	"fmt"
 	"github.com/cyverse-de/de-stats/cron"
 	"github.com/cyverse-de/de-stats/util"
 	"github.com/labstack/echo"
@@ -38,13 +37,11 @@ func verifyLoginParameters(ctx echo.Context) (string, string, error) {
 	oneWeekAgo := time.Now().AddDate(0, 0, -7)
 
 	startDate, err := util.StringQueryParam(ctx, "startDate", oneWeekAgo.Format(dateFormat))
-	fmt.Println(startDate)
 	if err != nil {
 		return "", "", ctx.JSON(http.StatusBadRequest, ErrorResponse{Description: err.Error()})
 	}
 
 	endDate, err := util.StringQueryParam(ctx, "endDate", currentTime.Format(dateFormat))
-	fmt.Println(endDate)
 	if err != nil{
 		return "", "", ctx.JSON(http.StatusBadRequest, ErrorResponse{Description: err.Error()})
 	}

--- a/api/loginsendpoint.go
+++ b/api/loginsendpoint.go
@@ -49,7 +49,7 @@ func verifyLoginParameters(ctx echo.Context) (string, string, error) {
 	return startDate, endDate, nil
 }
 
-func DistinceLoginCountHandler(ctx echo.Context) error {
+func DistinctLoginCountHandler(ctx echo.Context) error {
 
 	startDate, endDate, err := verifyLoginParameters(ctx)
 	if err != nil {

--- a/api/loginsendpoint.go
+++ b/api/loginsendpoint.go
@@ -26,27 +26,7 @@ type LoginsParams struct {
 
 type LoginsResponse struct {
 	Count int 	`json:"count"`
-}
-
-func BuildDistinctLoginCountHandler(db *sql.DB) func(echo.Context) error {
-	return func(ctx echo.Context) error {
-		startDate, endDate, err := util.VerifyDateParameters(ctx)
-		if err != nil {
-			return ctx.JSON(http.StatusBadRequest, ErrorResponse{Description: err.Error()})
-		}
-
-		login, err := cron.GetDistinctLoginCount(db, startDate, endDate)
-
-		if err != nil {
-			return err
-		}
-
-		resp := LoginsResponse{
-			Count: login.Count,
-		}
-
-		return ctx.JSON(http.StatusOK, resp)
-	}
+	DistinctCount int `json:"distinct"`
 }
 
 func BuildLoginCountHandler(db *sql.DB) func(echo.Context) error {
@@ -64,6 +44,7 @@ func BuildLoginCountHandler(db *sql.DB) func(echo.Context) error {
 
 		resp := LoginsResponse{
 			Count: login.Count,
+			DistinctCount: login.DistinctCount,
 		}
 
 		return ctx.JSON(http.StatusOK, resp)

--- a/api/loginsendpoint.go
+++ b/api/loginsendpoint.go
@@ -1,6 +1,7 @@
 package api
 
 import (
+	"database/sql"
 	"github.com/cyverse-de/de-stats/cron"
 	"github.com/cyverse-de/de-stats/util"
 	"github.com/labstack/echo"
@@ -27,44 +28,44 @@ type LoginsResponse struct {
 	Count int 	`json:"count"`
 }
 
-func DistinctLoginCountHandler(ctx echo.Context) error {
+func BuildDistinctLoginCountHandler(db *sql.DB) func(echo.Context) error {
+	return func(ctx echo.Context) error {
+		startDate, endDate, err := util.VerifyDateParameters(ctx)
+		if err != nil {
+			return ctx.JSON(http.StatusBadRequest, ErrorResponse{Description: err.Error()})
+		}
 
-	startDate, endDate, err := util.VerifyDateParameters(ctx)
-	if err != nil {
-		return ctx.JSON(http.StatusBadRequest, ErrorResponse{Description: err.Error()})
+		login, err := cron.GetDistinctLoginCount(db, startDate, endDate)
+
+		if err != nil {
+			return err
+		}
+
+		resp := LoginsResponse{
+			Count: login.Count,
+		}
+
+		return ctx.JSON(http.StatusOK, resp)
 	}
-
-	db := cron.InitDB()
-	login, err := cron.GetDistinctLoginCount(db, startDate, endDate)
-
-	if err != nil {
-		return err
-	}
-
-	resp := LoginsResponse{
-		Count: login.Count,
-	}
-
-	return ctx.JSON(http.StatusOK, resp)
-
 }
 
-func LoginCountHandler(ctx echo.Context) error {
-	startDate, endDate, err := util.VerifyDateParameters(ctx)
-	if err != nil {
-		return ctx.JSON(http.StatusBadRequest, ErrorResponse{Description: err.Error()})
+func BuildLoginCountHandler(db *sql.DB) func(echo.Context) error {
+	return func(ctx echo.Context) error {
+		startDate, endDate, err := util.VerifyDateParameters(ctx)
+		if err != nil {
+			return ctx.JSON(http.StatusBadRequest, ErrorResponse{Description: err.Error()})
+		}
+
+		login, err := cron.GetLoginCount(db, startDate, endDate)
+
+		if err != nil {
+			return err
+		}
+
+		resp := LoginsResponse{
+			Count: login.Count,
+		}
+
+		return ctx.JSON(http.StatusOK, resp)
 	}
-
-	db := cron.InitDB()
-	login, err := cron.GetLoginCount(db, startDate, endDate)
-
-	if err != nil {
-		return err
-	}
-
-	resp := LoginsResponse{
-		Count: login.Count,
-	}
-
-	return ctx.JSON(http.StatusOK, resp)
 }

--- a/api/main.go
+++ b/api/main.go
@@ -2,10 +2,9 @@ package api
 
 import (
 	"fmt"
-	"net/http"
-
 	"github.com/cyverse-de/de-stats/util"
 	"github.com/labstack/echo"
+	"net/http"
 )
 
 // swagger:parameters misc getRoot
@@ -47,3 +46,4 @@ func RootHandler(ctx echo.Context) error {
 	}
 	return ctx.JSON(http.StatusOK, resp)
 }
+

--- a/api/usersendpoint.go
+++ b/api/usersendpoint.go
@@ -6,6 +6,7 @@ import (
 	"github.com/labstack/echo"
 	"net/http"
 	"github.com/cyverse-de/de-stats/util"
+	"time"
 )
 
 type UsersParams struct {
@@ -35,12 +36,20 @@ type UsersResponse struct {
 
 func UsersHandler(ctx echo.Context) error{
 
-	days, err := util.IntQueryParam(ctx, "days", 1, 0, 365)
-	fmt.Println(days)
+	currentTime := time.Now()
+	oneWeekAgo := time.Now().AddDate(0, 0, -7)
+
+	startDate, err := util.StringQueryParam(ctx, "startDate", oneWeekAgo.Format("00/00/0000"))
+	fmt.Println(startDate)
 	if err != nil {
 		return ctx.JSON(http.StatusBadRequest, ErrorResponse{Description: err.Error()})
 	}
-	db := cron.InitDB()
+
+	endDate, err := util.StringQueryParam(ctx, "endDate", currentTime.Format("00/00/0000"))
+	fmt.Println(endDate)
+	if err != nil{
+		return ctx.JSON(http.StatusBadRequest, ErrorResponse{Description: err.Error()})
+	}
 
 	amount, err := util.IntQueryParam(ctx, "count", 10, 1, 1000)
 	fmt.Println(amount)
@@ -48,7 +57,8 @@ func UsersHandler(ctx echo.Context) error{
 		return ctx.JSON(http.StatusBadRequest, ErrorResponse{Description: err.Error()})
 	}
 
-	users, err := cron.GetTopUsers(db, amount, days)
+	db := cron.InitDB()
+	users, err := cron.GetTopUsers(db, amount, startDate, endDate)
 
 	if err != nil{
 		return err

--- a/api/usersendpoint.go
+++ b/api/usersendpoint.go
@@ -5,7 +5,6 @@ import (
 	"github.com/cyverse-de/de-stats/util"
 	"github.com/labstack/echo"
 	"net/http"
-	"time"
 )
 
 type UsersParams struct {
@@ -39,19 +38,8 @@ type UsersResponse struct {
 }
 
 func UsersHandler(ctx echo.Context) error{
-	const (
-		dateFormat = "20060102"
-	)
-	currentTime := time.Now()
-	oneWeekAgo := time.Now().AddDate(0, 0, -7)
-
-	startDate, err := util.StringQueryParam(ctx, "startDate", oneWeekAgo.Format(dateFormat))
+	startDate, endDate, err := util.VerifyDateParameters(ctx)
 	if err != nil {
-		return ctx.JSON(http.StatusBadRequest, ErrorResponse{Description: err.Error()})
-	}
-
-	endDate, err := util.StringQueryParam(ctx, "endDate", currentTime.Format(dateFormat))
-	if err != nil{
 		return ctx.JSON(http.StatusBadRequest, ErrorResponse{Description: err.Error()})
 	}
 

--- a/api/usersendpoint.go
+++ b/api/usersendpoint.go
@@ -1,11 +1,10 @@
 package api
 
 import (
-	"fmt"
 	"github.com/cyverse-de/de-stats/cron"
+	"github.com/cyverse-de/de-stats/util"
 	"github.com/labstack/echo"
 	"net/http"
-	"github.com/cyverse-de/de-stats/util"
 	"time"
 )
 
@@ -47,7 +46,6 @@ func UsersHandler(ctx echo.Context) error{
 	oneWeekAgo := time.Now().AddDate(0, 0, -7)
 
 	startDate, err := util.StringQueryParam(ctx, "startDate", oneWeekAgo.Format(dateFormat))
-	fmt.Println(startDate)
 	if err != nil {
 		return ctx.JSON(http.StatusBadRequest, ErrorResponse{Description: err.Error()})
 	}
@@ -56,15 +54,8 @@ func UsersHandler(ctx echo.Context) error{
 	if err != nil{
 		return ctx.JSON(http.StatusBadRequest, ErrorResponse{Description: err.Error()})
 	}
-	eDate, err := time.Parse(dateFormat, endDate)
-	if err != nil {
-		return err
-	}
-	endDate = eDate.AddDate(0, 0, 1).Format(dateFormat)
-	fmt.Println(endDate)
 
 	amount, err := util.IntQueryParam(ctx, "count", 10, 1, 1000)
-	fmt.Println(amount)
 	if err != nil {
 		return ctx.JSON(http.StatusBadRequest, ErrorResponse{Description: err.Error()})
 	}

--- a/cron/appstats.go
+++ b/cron/appstats.go
@@ -20,7 +20,7 @@ func GetTopApps(db *sql.DB, amount int, startDate string, endDate string) ([]App
 
 	query := `SELECT app_name, app_id, count(*) AS job_count FROM jobs
            WHERE start_date >= ($2 :: DATE)
-           AND start_date <= ($3 :: DATE)
+           AND start_date <= ($3 :: DATE) + INTERVAL '1 day'
            AND app_id != '1e8f719b-0452-4d39-a2f3-8714793ee3e6'
            GROUP BY app_name, app_id
            ORDER BY job_count DESC

--- a/cron/appstats.go
+++ b/cron/appstats.go
@@ -33,14 +33,14 @@ func GetTopApps(db *sql.DB, amount int, startDate string, endDate string) ([]App
 
 	defer rows.Close()
 
-	apps := make([]App, amount)
+	var apps []App
 	for i := 0; rows.Next(); i++{
 		err := rows.Scan(&name, &appID, &appCount)
 		if err != nil {
 			return nil, err
 		}
 
-		apps[i] = App{getStringValue(name), appID, appCount}
+		apps = append(apps, App{getStringValue(name), appID, appCount})
 		output := fmt.Sprintf("App name %[1]v App ID %[2]v App Count %[3]v", getStringValue(name), appID, appCount)
 		fmt.Println(output)
 

--- a/cron/appstats.go
+++ b/cron/appstats.go
@@ -1,17 +1,8 @@
 package cron
 
 import (
-	//"bufio"
-	//"bytes"
 	"database/sql"
 	"fmt"
-	//"io"
-	//"os"
-	//"path/filepath"
-	//"strings"
-	//"text/tabwriter"
-	//"time"
-
 	_ "github.com/lib/pq"
 )
 type App struct {
@@ -22,18 +13,19 @@ type App struct {
 
 
 
-func GetTopApps(db *sql.DB, amount int, days int) ([]App, error){
+func GetTopApps(db *sql.DB, amount int, startDate string, endDate string) ([]App, error){
 	var name *string
 	var appID string
 	var appCount int
 
 	query := `SELECT app_name, app_id, count(*) AS job_count FROM jobs
-           WHERE start_date >= (now() - ($2 || ' DAY')::INTERVAL )
+           WHERE start_date >= ($2 :: DATE)
+           AND start_date <= ($3 :: DATE)
            AND app_id != '1e8f719b-0452-4d39-a2f3-8714793ee3e6'
            GROUP BY app_name, app_id
            ORDER BY job_count DESC
            LIMIT $1`
-	rows, err := db.Query(query, amount, days)
+	rows, err := db.Query(query, amount, startDate, endDate)
 
 	if err != nil {
 		return nil, err

--- a/cron/appstats.go
+++ b/cron/appstats.go
@@ -2,7 +2,6 @@ package cron
 
 import (
 	"database/sql"
-	"fmt"
 	_ "github.com/lib/pq"
 )
 type App struct {
@@ -42,8 +41,6 @@ func GetTopApps(db *sql.DB, amount int, startDate string, endDate string) ([]App
 		}
 
 		apps = append(apps, app)
-		output := fmt.Sprintf("App name %[1]v App ID %[2]v App Count %[3]v", app.Name, app.ID, app.Count)
-		fmt.Println(output)
 
 	}
 	err = rows.Err()

--- a/cron/appstats.go
+++ b/cron/appstats.go
@@ -15,7 +15,13 @@ func GetTopApps(db *sql.DB, amount int, startDate string, endDate string) ([]App
 	query := `SELECT app_name, app_id, count(*) AS job_count FROM jobs
            WHERE start_date >= ($2 :: DATE)
            AND start_date <= ($3 :: DATE) + INTERVAL '1 day'
-           AND app_id != '1e8f719b-0452-4d39-a2f3-8714793ee3e6'
+           AND app_id NOT IN (
+           		SELECT app_steps.app_id::TEXT FROM app_steps
+    			JOIN tasks ON app_steps.task_id = tasks.id
+   				JOIN tools ON tasks.tool_id = tools.id
+    			JOIN tool_types ON tools.tool_type_id = tool_types.id
+    			WHERE tool_types.name = 'internal'
+           )
            GROUP BY app_name, app_id
            ORDER BY job_count DESC
            LIMIT $1`

--- a/cron/appstats.go
+++ b/cron/appstats.go
@@ -11,13 +11,7 @@ type App struct {
 	Count	int
 }
 
-
-
 func GetTopApps(db *sql.DB, amount int, startDate string, endDate string) ([]App, error){
-	var name *string
-	var appID string
-	var appCount int
-
 	query := `SELECT app_name, app_id, count(*) AS job_count FROM jobs
            WHERE start_date >= ($2 :: DATE)
            AND start_date <= ($3 :: DATE) + INTERVAL '1 day'
@@ -34,14 +28,15 @@ func GetTopApps(db *sql.DB, amount int, startDate string, endDate string) ([]App
 	defer rows.Close()
 
 	var apps []App
-	for i := 0; rows.Next(); i++{
-		err := rows.Scan(&name, &appID, &appCount)
+	for rows.Next(){
+		var app App
+		err := rows.Scan(&app.Name, &app.ID, &app.Count)
 		if err != nil {
 			return nil, err
 		}
 
-		apps = append(apps, App{getStringValue(name), appID, appCount})
-		output := fmt.Sprintf("App name %[1]v App ID %[2]v App Count %[3]v", getStringValue(name), appID, appCount)
+		apps = append(apps, app)
+		output := fmt.Sprintf("App name %[1]v App ID %[2]v App Count %[3]v", app.Name, app.ID, app.Count)
 		fmt.Println(output)
 
 	}

--- a/cron/jobstats.go
+++ b/cron/jobstats.go
@@ -12,7 +12,7 @@ type Job struct {
 }
 
 //jobs/submitted
-func GetSubmittedJobCounts(db *sql.DB, startDay string, endDay string)([]Job, error) {
+func GetSubmittedJobCounts(db *sql.DB, startDate string, endDate string)([]Job, error) {
 	var jobType *string
 	var count int
 	//skip curl wrapper jobs
@@ -26,7 +26,7 @@ func GetSubmittedJobCounts(db *sql.DB, startDay string, endDay string)([]Job, er
                SELECT j.id, array_agg(DISTINCT t.name) AS types FROM jobs j
                JOIN job_steps s ON j.id = s.job_id
                JOIN job_types t ON s.job_type_id = t.id
-               WHERE j.start_date >= ($1 :: DATE) AND j.start_date <= ($2 :: DATE)
+               WHERE j.start_date >= ($1 :: DATE) AND j.start_date <= ($2 :: DATE) + INTERVAL '1 day'
                AND j.app_id != '1e8f719b-0452-4d39-a2f3-8714793ee3e6'
                GROUP BY j.id
            ) AS a
@@ -34,7 +34,7 @@ func GetSubmittedJobCounts(db *sql.DB, startDay string, endDay string)([]Job, er
          GROUP BY b.job_type
          ORDER BY b.job_type;`
 
-	rows, err := db.Query(query, startDay, endDay)
+	rows, err := db.Query(query, startDate, endDate)
 	if err != nil {
 		return nil, err
 	}
@@ -63,7 +63,7 @@ func GetSubmittedJobCounts(db *sql.DB, startDay string, endDay string)([]Job, er
 }
 
 //jobs/status
-func GetJobStatusCounts(db *sql.DB, startDay string, endDay string)([]Job, error){
+func GetJobStatusCounts(db *sql.DB, startDate string, endDate string)([]Job, error){
 	var jobType *string
 	var count int
 	var status *string
@@ -78,7 +78,7 @@ func GetJobStatusCounts(db *sql.DB, startDay string, endDay string)([]Job, error
                SELECT j.id, j.status, array_agg(DISTINCT t.name) AS types FROM jobs j
                JOIN job_steps s ON j.id = s.job_id
                JOIN job_types t ON s.job_type_id = t.id
-               WHERE j.start_date >= ($1 :: DATE) AND j.start_date <= ($2 :: DATE)
+               WHERE j.start_date >= ($1 :: DATE) AND j.start_date <= ($2 :: DATE) + INTERVAL '1 day'
                AND j.app_id != '1e8f719b-0452-4d39-a2f3-8714793ee3e6'
                AND j.status in ('Completed', 'Failed', 'Canceled')
                GROUP BY j.id
@@ -87,7 +87,7 @@ func GetJobStatusCounts(db *sql.DB, startDay string, endDay string)([]Job, error
          GROUP BY b.job_type, b.status
          ORDER BY b.job_type;`
 
-	rows, err := db.Query(query, startDay, endDay)
+	rows, err := db.Query(query, startDate, endDate)
 	if err != nil {
 		return nil, err;
 	}

--- a/cron/jobstats.go
+++ b/cron/jobstats.go
@@ -5,16 +5,14 @@ import (
 	"fmt"
 )
 
-type Job struct {
+type JobStats struct {
 	Category	string
 	Status		string
 	Count		int
 }
 
 //jobs/submitted
-func GetSubmittedJobCounts(db *sql.DB, startDate string, endDate string)([]Job, error) {
-	var jobType *string
-	var count int
+func GetSubmittedJobCounts(db *sql.DB, startDate string, endDate string)([]JobStats, error) {
 	//skip curl wrapper jobs
 	query := `SELECT b.job_type, count(b.*) AS count
             FROM (
@@ -41,15 +39,16 @@ func GetSubmittedJobCounts(db *sql.DB, startDate string, endDate string)([]Job, 
 
 	defer rows.Close()
 
-	var jobs []Job
+	var jobs []JobStats
 
 	for i := 0; rows.Next(); i++ {
-		err := rows.Scan(&jobType, &count)
+		var job JobStats
+		err := rows.Scan(&job.Category, &job.Status, &job.Count)
 		if err != nil {
 			return nil, err
 		}
-		jobs = append(jobs, Job{getStringValue(jobType), "Submitted", count})
-		output := fmt.Sprintf("Total no.of %[1]v jobs Submitted in last 24 hours: %[2]v", getStringValue(jobType), count)
+		jobs = append(jobs, job)
+		output := fmt.Sprintf("Total no.of %[1]v jobs Submitted in last 24 hours: %[2]v", job.Category, job.Count)
 		fmt.Println(output)
 
 	}
@@ -63,10 +62,7 @@ func GetSubmittedJobCounts(db *sql.DB, startDate string, endDate string)([]Job, 
 }
 
 //jobs/status
-func GetJobStatusCounts(db *sql.DB, startDate string, endDate string)([]Job, error){
-	var jobType *string
-	var count int
-	var status *string
+func GetJobStatusCounts(db *sql.DB, startDate string, endDate string)([]JobStats, error){
 
 	query := `SELECT b.job_type, b.status, count(b.*) AS count
             FROM (
@@ -94,15 +90,16 @@ func GetJobStatusCounts(db *sql.DB, startDate string, endDate string)([]Job, err
 
 	defer rows.Close()
 
-	var jobs []Job
+	var jobs []JobStats
 
-	for i := 0; rows.Next(); i++ {
-		err := rows.Scan(&jobType, &status, &count)
+	for rows.Next() {
+		var job JobStats
+		err := rows.Scan(&job.Category, &job.Status, &job.Count)
 		if err != nil {
 			return nil, err;
 		}
-		jobs = append(jobs, Job{getStringValue(jobType), getStringValue(status), count})
-		output := fmt.Sprintf("Total no.of %[1]v jobs %[2]v: %[3]v", getStringValue(jobType), getStringValue(status), count)
+		jobs = append(jobs, job)
+		output := fmt.Sprintf("Total no.of %[1]v jobs %[2]v: %[3]v", job.Category, job.Status, job.Count)
 		fmt.Println(output)
 	}
 

--- a/cron/jobstats.go
+++ b/cron/jobstats.go
@@ -1,0 +1,63 @@
+package cron
+
+import (
+	"database/sql"
+	"fmt"
+)
+
+type Job struct {
+	Category	string
+	Status		string
+	Count		int
+}
+
+//jobs/submitted
+func getSubmittedJobCounts(db *sql.DB, startDay string, endDay string)([]Job, error) {
+	var jobType *string
+	var count int
+	//skip curl wrapper jobs
+	query := `SELECT b.job_type, count(b.*) AS count
+            FROM (
+              SELECT a.id,
+                CASE WHEN array_length(a.types, 1) = 1 THEN a.types[1]
+              ELSE 'Mixed'
+           END AS job_type
+           FROM (
+               SELECT j.id, array_agg(DISTINCT t.name) AS types FROM jobs j
+               JOIN job_steps s ON j.id = s.job_id
+               JOIN job_types t ON s.job_type_id = t.id
+               WHERE j.start_date >= ($2 :: DATE) AND j.start_date <= ($3 :: DATE)
+               AND j.app_id != '1e8f719b-0452-4d39-a2f3-8714793ee3e6'
+               GROUP BY j.id
+           ) AS a
+          ) AS b
+         GROUP BY b.job_type
+         ORDER BY b.job_type;`
+
+	rows, err := db.Query(query)
+	if err != nil {
+		return nil, err
+	}
+
+	defer rows.Close()
+
+	jobs := make([]Job, 3)
+
+	for i := 0; rows.Next(); i++ {
+		err := rows.Scan(&jobType, &count)
+		if err != nil {
+			return nil, err
+		}
+		jobs[i] = Job{getStringValue(jobType), "Submitted", count}
+		output := fmt.Sprintf("Total no.of %[1]v jobs Submitted in last 24 hours: %[2]v", getStringValue(jobType), count)
+		fmt.Println(output)
+
+	}
+
+	err = rows.Err()
+	if err != nil {
+		return nil, err
+	}
+
+	return jobs, nil
+}

--- a/cron/jobstats.go
+++ b/cron/jobstats.go
@@ -14,7 +14,7 @@ type JobStats struct {
 //jobs/submitted
 func GetSubmittedJobCounts(db *sql.DB, startDate string, endDate string)([]JobStats, error) {
 	//skip curl wrapper jobs
-	query := `SELECT b.job_type, count(b.*) AS count
+	query := `SELECT b.job_type, 'Submitted', count(b.*) AS count
             FROM (
               SELECT a.id,
                 CASE WHEN array_length(a.types, 1) = 1 THEN a.types[1]

--- a/cron/jobstats.go
+++ b/cron/jobstats.go
@@ -11,77 +11,57 @@ type JobStats struct {
 	Count		int
 }
 
-//jobs/submitted
-func GetSubmittedJobCounts(db *sql.DB, startDate string, endDate string)([]JobStats, error) {
-	//skip curl wrapper jobs
-	query := `SELECT b.job_type, 'Submitted', count(b.*) AS count
-            FROM (
-              SELECT a.id,
-                CASE WHEN array_length(a.types, 1) = 1 THEN a.types[1]
-              ELSE 'Mixed'
-           END AS job_type
-           FROM (
-               SELECT j.id, array_agg(DISTINCT t.name) AS types FROM jobs j
-               JOIN job_steps s ON j.id = s.job_id
-               JOIN job_types t ON s.job_type_id = t.id
-               WHERE j.start_date >= ($1 :: DATE) AND j.start_date <= ($2 :: DATE) + INTERVAL '1 day'
-               AND j.app_id != '1e8f719b-0452-4d39-a2f3-8714793ee3e6'
-               GROUP BY j.id
-           ) AS a
-          ) AS b
-         GROUP BY b.job_type
-         ORDER BY b.job_type;`
+//jobs/counts
+func GetJobCounts(db *sql.DB, startDate string, endDate string)([]JobStats, error){
 
-	rows, err := db.Query(query, startDate, endDate)
-	if err != nil {
-		return nil, err
-	}
-
-	defer rows.Close()
-
-	var jobs []JobStats
-
-	for i := 0; rows.Next(); i++ {
-		var job JobStats
-		err := rows.Scan(&job.Category, &job.Status, &job.Count)
-		if err != nil {
-			return nil, err
-		}
-		jobs = append(jobs, job)
-		output := fmt.Sprintf("Total no.of %[1]v jobs Submitted in last 24 hours: %[2]v", job.Category, job.Count)
-		fmt.Println(output)
-
-	}
-
-	err = rows.Err()
-	if err != nil {
-		return nil, err
-	}
-
-	return jobs, nil
-}
-
-//jobs/status
-func GetJobStatusCounts(db *sql.DB, startDate string, endDate string)([]JobStats, error){
-
-	query := `SELECT b.job_type, b.status, count(b.*) AS count
-            FROM (
-              SELECT a.id,a.status,
-                CASE WHEN array_length(a.types, 1) = 1 THEN a.types[1]
-              ELSE 'Mixed'
-           END AS job_type
-           FROM (
-               SELECT j.id, j.status, array_agg(DISTINCT t.name) AS types FROM jobs j
-               JOIN job_steps s ON j.id = s.job_id
-               JOIN job_types t ON s.job_type_id = t.id
-               WHERE j.start_date >= ($1 :: DATE) AND j.start_date <= ($2 :: DATE) + INTERVAL '1 day'
-               AND j.app_id != '1e8f719b-0452-4d39-a2f3-8714793ee3e6'
-               AND j.status in ('Completed', 'Failed', 'Canceled')
-               GROUP BY j.id
-           ) AS a
-          ) AS b
-         GROUP BY b.job_type, b.status
-         ORDER BY b.job_type;`
+	query := `WITH internal_app_ids AS (
+				SELECT app_steps.app_id::TEXT FROM app_steps
+				JOIN tasks ON app_steps.task_id = tasks.id
+				JOIN tools ON tasks.tool_id = tools.id
+				JOIN tool_types ON tools.tool_type_id = tool_types.id
+				WHERE tool_types.name = 'internal'
+			)
+			SELECT c.job_type, c.status, c.count FROM (
+				SELECT b.job_type, 'Submitted' AS status, count(b.*) AS count
+				FROM (
+					SELECT
+						a.id,
+						CASE
+							WHEN array_length(a.types, 1) = 1 THEN a.types[1]
+							ELSE 'Mixed'
+						END AS job_type
+					FROM (
+						SELECT j.id, array_agg(DISTINCT t.name) AS types FROM jobs j
+						JOIN job_steps s ON j.id = s.job_id
+						JOIN job_types t ON s.job_type_id = t.id
+						WHERE j.start_date >= ($1 :: DATE) AND j.start_date <= ($2 :: DATE) + INTERVAL '1 day'
+						AND j.app_id NOT IN (SELECT app_id FROM internal_app_ids)
+						GROUP BY j.id
+					) AS a
+				) AS b
+				GROUP BY b.job_type
+				UNION
+				SELECT b.job_type, b.status, count(b.*) AS count
+				FROM (
+					SELECT
+						a.id,a.status,
+						CASE
+							WHEN array_length(a.types, 1) = 1 THEN a.types[1]
+							ELSE 'Mixed'
+						END AS job_type
+					FROM (
+						SELECT j.id, j.status, array_agg(t.name) AS types FROM jobs j
+						JOIN job_steps s ON j.id = s.job_id
+						JOIN job_types t ON s.job_type_id = t.id
+						WHERE j.end_date >= ($1 :: DATE) AND j.end_date <= ($2 :: DATE) + INTERVAL '1 day'
+						AND j.app_id NOT IN (SELECT app_id FROM internal_app_ids)
+						AND j.status in ('Completed', 'Failed', 'Canceled')
+						GROUP BY j.id
+					) AS a
+				) AS b
+				GROUP BY b.job_type, b.status
+			) AS c
+			ORDER BY c.job_type, c.status`
 
 	rows, err := db.Query(query, startDate, endDate)
 	if err != nil {

--- a/cron/jobstats.go
+++ b/cron/jobstats.go
@@ -12,7 +12,7 @@ type Job struct {
 }
 
 //jobs/submitted
-func getSubmittedJobCounts(db *sql.DB, startDay string, endDay string)([]Job, error) {
+func GetSubmittedJobCounts(db *sql.DB, startDay string, endDay string)([]Job, error) {
 	var jobType *string
 	var count int
 	//skip curl wrapper jobs

--- a/cron/jobstats.go
+++ b/cron/jobstats.go
@@ -2,7 +2,6 @@ package cron
 
 import (
 	"database/sql"
-	"fmt"
 )
 
 type JobStats struct {
@@ -79,8 +78,6 @@ func GetJobCounts(db *sql.DB, startDate string, endDate string)([]JobStats, erro
 			return nil, err;
 		}
 		jobs = append(jobs, job)
-		output := fmt.Sprintf("Total no.of %[1]v jobs %[2]v: %[3]v", job.Category, job.Status, job.Count)
-		fmt.Println(output)
 	}
 
 	err = rows.Err()

--- a/cron/loginstats.go
+++ b/cron/loginstats.go
@@ -1,6 +1,8 @@
 package cron
 
-import "database/sql"
+import (
+	"database/sql"
+)
 
 type LoginCount struct {
 	Count int

--- a/cron/loginstats.go
+++ b/cron/loginstats.go
@@ -6,42 +6,26 @@ import (
 
 type LoginCount struct {
 	Count int
+	DistinctCount int
 }
 
-// /logins/distinct
-func GetDistinctLoginCount(db *sql.DB, startDate string, endDate string) (LoginCount, error){
-	var count int
-
-	query := `SELECT count(distinct user_id) FROM logins WHERE login_time >= ($1 :: DATE )
-		AND login_time <= ($2 :: DATE) + INTERVAL '1 day';`
-
-	row := db.QueryRow(query, startDate, endDate)
-
-	var logins LoginCount
-	err := row.Scan(&logins.Count)
-	if err != nil {
-		return LoginCount{-1}, err
-	}
-	logins.Count = count
-
-	return logins, nil
-}
-
-// /login
+// /logins
 func GetLoginCount(db *sql.DB, startDate string, endDate string) (LoginCount, error){
 	var count int
-
-	query := `select count(user_id) from logins where login_time >= ($1 :: DATE) 
+	var distinctCount int
+	query := `select count(user_id), count(distinct user_id) from logins where login_time >= ($1 :: DATE) 
 		AND login_time <= ($2 :: DATE) + INTERVAL  '1 day';`
 
 	row := db.QueryRow(query, startDate, endDate)
 
 	var logins LoginCount
-	err := row.Scan(&logins.Count)
+	logins = LoginCount{0, 0}
+	err := row.Scan(&count, &distinctCount)
+
 	if err != nil {
-		return LoginCount{-1}, err
+		return LoginCount{-1, -1}, err
 	}
 	logins.Count = count
-
+	logins.DistinctCount = distinctCount
 	return logins, nil
 }

--- a/cron/loginstats.go
+++ b/cron/loginstats.go
@@ -11,7 +11,7 @@ func GetDistinctLoginCount(db *sql.DB, startDate string, endDate string) (Login,
 	var count int
 
 	query := `SELECT count(distinct user_id) FROM logins WHERE login_time >= ($1 :: DATE )
-		AND login_time <= ($2 :: DATE);`
+		AND login_time <= ($2 :: DATE) + INTERVAL '1 day';`
 
 	rows, err := db.Query(query, startDate, endDate)
 
@@ -43,7 +43,7 @@ func GetLoginCount(db *sql.DB, startDate string, endDate string) (Login, error){
 	var count int
 
 	query := `select count(user_id) from logins where login_time >= ($1 :: DATE) 
-		AND login_time <= ($2 :: DATE);`
+		AND login_time <= ($2 :: DATE) + INTERVAL  '1 day';`
 
 	rows, err := db.Query(query, startDate, endDate)
 	if err != nil {

--- a/cron/loginstats.go
+++ b/cron/loginstats.go
@@ -1,0 +1,70 @@
+package cron
+
+import "database/sql"
+
+type Login struct {
+	Count int
+}
+
+// /logins/distinct
+func GetDistinctLoginCount(db *sql.DB, startDate string, endDate string) (Login, error){
+	var count int
+
+	query := `SELECT count(distinct user_id) FROM logins WHERE login_time >= ($1 :: DATE )
+		AND login_time <= ($2 :: DATE);`
+
+	rows, err := db.Query(query, startDate, endDate)
+
+	if err != nil {
+		return Login{-1}, err
+	}
+
+	defer rows.Close()
+	var logins Login
+	logins = Login{0}
+	for rows.Next() {
+		err := rows.Scan(&count)
+		if err != nil {
+			return Login{-1}, err
+		}
+		logins.Count += count
+	}
+
+	err = rows.Err()
+	if err != nil {
+		return Login{-1}, err
+	}
+
+	return logins, nil
+}
+
+// /login
+func GetLoginCount(db *sql.DB, startDate string, endDate string) (Login, error){
+	var count int
+
+	query := `select count(user_id) from logins where login_time >= ($1 :: DATE) 
+		AND login_time <= ($2 :: DATE);`
+
+	rows, err := db.Query(query, startDate, endDate)
+	if err != nil {
+		return Login{-1}, err
+	}
+
+	defer rows.Close()
+	var logins Login
+	logins = Login{0}
+	for rows.Next(){
+		err := rows.Scan(&count)
+		if err != nil {
+			return Login{-1}, err
+		}
+		logins.Count += count
+	}
+
+	err = rows.Err()
+	if err != nil {
+		return Login{-1}, err
+	}
+
+	return logins, nil
+}

--- a/cron/loginstats.go
+++ b/cron/loginstats.go
@@ -18,9 +18,7 @@ func GetDistinctLoginCount(db *sql.DB, startDate string, endDate string) (LoginC
 	row := db.QueryRow(query, startDate, endDate)
 
 	var logins LoginCount
-	logins = LoginCount{0}
-	err := row.Scan(&count)
-
+	err := row.Scan(&logins.Count)
 	if err != nil {
 		return LoginCount{-1}, err
 	}
@@ -39,14 +37,11 @@ func GetLoginCount(db *sql.DB, startDate string, endDate string) (LoginCount, er
 	row := db.QueryRow(query, startDate, endDate)
 
 	var logins LoginCount
-	logins = LoginCount{0}
-	err := row.Scan(&count)
-
+	err := row.Scan(&logins.Count)
 	if err != nil {
 		return LoginCount{-1}, err
 	}
 	logins.Count = count
-
 
 	return logins, nil
 }

--- a/cron/loginstats.go
+++ b/cron/loginstats.go
@@ -2,69 +2,49 @@ package cron
 
 import "database/sql"
 
-type Login struct {
+type LoginCount struct {
 	Count int
 }
 
 // /logins/distinct
-func GetDistinctLoginCount(db *sql.DB, startDate string, endDate string) (Login, error){
+func GetDistinctLoginCount(db *sql.DB, startDate string, endDate string) (LoginCount, error){
 	var count int
 
 	query := `SELECT count(distinct user_id) FROM logins WHERE login_time >= ($1 :: DATE )
 		AND login_time <= ($2 :: DATE) + INTERVAL '1 day';`
 
-	rows, err := db.Query(query, startDate, endDate)
+	row := db.QueryRow(query, startDate, endDate)
+
+	var logins LoginCount
+	logins = LoginCount{0}
+	err := row.Scan(&count)
 
 	if err != nil {
-		return Login{-1}, err
+		return LoginCount{-1}, err
 	}
-
-	defer rows.Close()
-	var logins Login
-	logins = Login{0}
-	for rows.Next() {
-		err := rows.Scan(&count)
-		if err != nil {
-			return Login{-1}, err
-		}
-		logins.Count += count
-	}
-
-	err = rows.Err()
-	if err != nil {
-		return Login{-1}, err
-	}
+	logins.Count = count
 
 	return logins, nil
 }
 
 // /login
-func GetLoginCount(db *sql.DB, startDate string, endDate string) (Login, error){
+func GetLoginCount(db *sql.DB, startDate string, endDate string) (LoginCount, error){
 	var count int
 
 	query := `select count(user_id) from logins where login_time >= ($1 :: DATE) 
 		AND login_time <= ($2 :: DATE) + INTERVAL  '1 day';`
 
-	rows, err := db.Query(query, startDate, endDate)
-	if err != nil {
-		return Login{-1}, err
-	}
+	row := db.QueryRow(query, startDate, endDate)
 
-	defer rows.Close()
-	var logins Login
-	logins = Login{0}
-	for rows.Next(){
-		err := rows.Scan(&count)
-		if err != nil {
-			return Login{-1}, err
-		}
-		logins.Count += count
-	}
+	var logins LoginCount
+	logins = LoginCount{0}
+	err := row.Scan(&count)
 
-	err = rows.Err()
 	if err != nil {
-		return Login{-1}, err
+		return LoginCount{-1}, err
 	}
+	logins.Count = count
+
 
 	return logins, nil
 }

--- a/cron/userstats.go
+++ b/cron/userstats.go
@@ -10,18 +10,18 @@ type User struct {
 	Count int
 }
 
-func GetTopUsers(db *sql.DB, amount int, days int) ([]User, error){
+func GetTopUsers(db *sql.DB, amount int, startDate string, endDate string) ([]User, error){
 	var username *string
 	var count int
 
 	query := `SELECT regexp_replace(u.username, '@.*', '') AS username, count(*) AS count  FROM jobs j
            JOIN users u ON j.user_id = u.id
-           WHERE j.start_date >= (now() - interval '1 day')
+           WHERE j.start_date >= ($2 :: DATE) AND j.start_date <= ($3 :: DATE)
            GROUP BY u.username
            ORDER BY count DESC
-		   LIMIT ;`
+		   LIMIT $1;`
 
-	rows, err := db.Query(query, amount, days)
+	rows, err := db.Query(query, amount, startDate, endDate)
 
 	if err != nil {
 		return nil, err

--- a/cron/userstats.go
+++ b/cron/userstats.go
@@ -11,8 +11,6 @@ type User struct {
 }
 
 func GetTopUsers(db *sql.DB, amount int, startDate string, endDate string) ([]User, error){
-	var username *string
-	var count int
 
 	query := `SELECT regexp_replace(u.username, '@.*', '') AS username, count(*) AS count  FROM jobs j
            JOIN users u ON j.user_id = u.id
@@ -31,13 +29,14 @@ func GetTopUsers(db *sql.DB, amount int, startDate string, endDate string) ([]Us
 
 	var users []User
 
-	for i := 0; rows.Next(); i++{
-		err := rows.Scan(&username, &count)
+	for rows.Next(){
+		var user User
+		err := rows.Scan(&user.Name, &user.Name)
 		if err != nil {
 			return nil, err
 		}
-		users = append(users, User{getStringValue(username), count})
-		output := fmt.Sprintf("Username %[1]v Count %[2]v", getStringValue(username), count)
+		users = append(users, user)
+		output := fmt.Sprintf("Username %[1]v Count %[2]v", user.Name, user.Count)
 		fmt.Println(output)
 
 	}

--- a/cron/userstats.go
+++ b/cron/userstats.go
@@ -29,15 +29,15 @@ func GetTopUsers(db *sql.DB, amount int, startDate string, endDate string) ([]Us
 
 	defer rows.Close()
 
-	users := make([]User, amount)
+	var users []User
 
 	for i := 0; rows.Next(); i++{
 		err := rows.Scan(&username, &count)
 		if err != nil {
 			return nil, err
 		}
-		users[i] = User{getStringValue(username), count}
-		output := fmt.Sprintf("Username %[1]v Count %[3]v", getStringValue(username), count)
+		users = append(users, User{getStringValue(username), count})
+		output := fmt.Sprintf("Username %[1]v Count %[2]v", getStringValue(username), count)
 		fmt.Println(output)
 
 	}

--- a/cron/userstats.go
+++ b/cron/userstats.go
@@ -1,7 +1,7 @@
 package cron
+
 import (
 	"database/sql"
-	"fmt"
 	_ "github.com/lib/pq"
 )
 
@@ -31,13 +31,11 @@ func GetTopUsers(db *sql.DB, amount int, startDate string, endDate string) ([]Us
 
 	for rows.Next(){
 		var user User
-		err := rows.Scan(&user.Name, &user.Name)
+		err := rows.Scan(&user.Name, &user.Count)
 		if err != nil {
 			return nil, err
 		}
 		users = append(users, user)
-		output := fmt.Sprintf("Username %[1]v Count %[2]v", user.Name, user.Count)
-		fmt.Println(output)
 
 	}
 

--- a/cron/userstats.go
+++ b/cron/userstats.go
@@ -16,7 +16,7 @@ func GetTopUsers(db *sql.DB, amount int, startDate string, endDate string) ([]Us
 
 	query := `SELECT regexp_replace(u.username, '@.*', '') AS username, count(*) AS count  FROM jobs j
            JOIN users u ON j.user_id = u.id
-           WHERE j.start_date >= ($2 :: DATE) AND j.start_date <= ($3 :: DATE)
+           WHERE j.start_date >= ($2 :: DATE) AND j.start_date <= ($3 :: DATE) + INTERVAL '1 day'
            GROUP BY u.username
            ORDER BY count DESC
 		   LIMIT $1;`

--- a/docs/main.go
+++ b/docs/main.go
@@ -37,14 +37,41 @@ type errorResponseWrapper struct {
 	Body api.ErrorResponse
 }
 
-// swagger:route GET /apps getTopApps
+// swagger:route GET /apps GetTopApps
 // Returns the top apps in the given time period.
 // Responses:
 // 200: appsResponse
+// 400: errorResponse
 
 //Top apps in time period.
 //swagger:response appsResponse
 type appsResponseWrapper struct {
 	// in:body
 	Body api.AppsResponse
+}
+
+// swagger:route GET /users GetTopUsers
+// Returns the top users in the given time period.
+// Responses:
+// 200: usersResponse
+// 400: errorResponse
+
+//Top users in time period
+//swagger:response usersResponse
+type usersResponseWrapper struct {
+	// in:body
+	Body api.UsersResponse
+}
+
+// swagger:route GET /jobs/submitted GetSubmittedJobCounts
+// Returns the number of submitted jobs in the given time period for each job type.
+// Responses:
+// 200: usersResponse
+// 400: errorResponse
+
+//Top users in time period
+//swagger:response usersResponse
+type jobsResponseWrapper struct {
+	// in:body
+	Body api.JobsResponse
 }

--- a/docs/main.go
+++ b/docs/main.go
@@ -63,22 +63,9 @@ type usersResponseWrapper struct {
 	Body api.UsersResponse
 }
 
-// swagger:route GET /jobs/submitted GetSubmittedJobCounts
-// Returns the number of submitted jobs in the given time period for each job type (DE, OSG, etc.).
-// Responses:
-// 200: usersResponse
-// 400: errorResponse
-
-//Submitted jobs in a time period
-//swagger:response JobsResponse
-type jobsSubmittedResponseWrapper struct {
-	// in:body
-	Body api.JobsResponse
-}
-
-// swagger:route GET /jobs/status GetJobStatusCounts
+// swagger:route GET /jobs/counts GetJobCounts
 // Returns the job count in the given time period for each job type (DE, OSG, etc.), and what their status
-// was (passed, failed, cancelled).
+// was (passed, failed, cancelled, submitted).
 // Responses:
 // 200: usersResponse
 // 400: errorResponse

--- a/docs/main.go
+++ b/docs/main.go
@@ -77,7 +77,7 @@ type jobsSubmittedResponseWrapper struct {
 }
 
 // swagger:route GET /jobs/status GetJobStatusCounts
-// Returns the number of job count in the given time period for each job type (DE, OSG, etc.), and what their status
+// Returns the job count in the given time period for each job type (DE, OSG, etc.), and what their status
 // was (passed, failed, cancelled).
 // Responses:
 // 200: usersResponse

--- a/docs/main.go
+++ b/docs/main.go
@@ -64,14 +64,54 @@ type usersResponseWrapper struct {
 }
 
 // swagger:route GET /jobs/submitted GetSubmittedJobCounts
-// Returns the number of submitted jobs in the given time period for each job type.
+// Returns the number of submitted jobs in the given time period for each job type (DE, OSG, etc.).
 // Responses:
 // 200: usersResponse
 // 400: errorResponse
 
-//Top users in time period
-//swagger:response usersResponse
-type jobsResponseWrapper struct {
+//Submitted jobs in a time period
+//swagger:response JobsResponse
+type jobsSubmittedResponseWrapper struct {
 	// in:body
 	Body api.JobsResponse
+}
+
+// swagger:route GET /jobs/status GetJobStatusCounts
+// Returns the number of job count in the given time period for each job type (DE, OSG, etc.), and what their status
+// was (passed, failed, cancelled).
+// Responses:
+// 200: usersResponse
+// 400: errorResponse
+
+//Job counts and their status in a time period
+//swagger:response JobsResponse
+type jobsStatusResponseWrapper struct {
+	// in:body
+	Body api.JobsResponse
+}
+
+// swagger:route GET /logins/distinct GetDistinctLoginCount
+// Return the total number of distinct logins in a given time period
+// Responses:
+// 200: usersResponse
+// 400: errorResponse
+
+//Distinct logins in a time period
+//swagger:response LoginsResponse
+type loginsDistinctResponseWrapper struct {
+	// in:body
+	Body api.LoginsResponse
+}
+
+// swagger:route GET /logins GetLoginCount
+// Return the total number of logins in a given time period
+// Responses:
+// 200: usersResponse
+// 400: errorResponse
+
+//All logins in a time period
+//swagger:response LoginsResponse
+type loginsResponseWrapper struct {
+	// in:body
+	Body api.LoginsResponse
 }

--- a/main.go
+++ b/main.go
@@ -24,7 +24,6 @@ func main() {
 	e.GET("/users", api.BuildUsersHandler(db))
 	e.GET("/jobs/counts", api.BuildJobsHandler(db))
 	e.GET("/logins", api.BuildLoginCountHandler(db))
-	e.GET("/logins/distinct", api.BuildDistinctLoginCountHandler(db))
 
 	e.Logger.Fatal(e.Start(":8080"))
 }

--- a/main.go
+++ b/main.go
@@ -22,8 +22,7 @@ func main() {
 
 	e.GET("/apps", api.BuildAppsHandler(db))
 	e.GET("/users", api.BuildUsersHandler(db))
-	e.GET("/jobs/submitted", api.BuildJobsSubmittedHandler(db))
-	e.GET("/jobs/status", api.BuildJobsStatusHandler(db))
+	e.GET("/jobs/counts", api.BuildJobsHandler(db))
 	e.GET("/logins", api.BuildLoginCountHandler(db))
 	e.GET("/logins/distinct", api.BuildDistinctLoginCountHandler(db))
 

--- a/main.go
+++ b/main.go
@@ -25,6 +25,8 @@ func main() {
 	e.GET("/users", api.UsersHandler)
 	e.GET("/jobs/submitted", api.JobsSubmittedHandler)
 	e.GET("/jobs/status", api.JobsStatusHandler)
+	e.GET("/logins", api.LoginCountHandler)
+	e.GET("/logins/distinct", api.DistinceLoginCountHandler)
 
 	e.Logger.Fatal(e.Start(":8080"))
 }

--- a/main.go
+++ b/main.go
@@ -22,6 +22,8 @@ func main() {
 	e.GET("/", api.RootHandler)
 
 	e.GET("/apps", api.AppsHandler)
+	e.GET("/users", api.UsersHandler)
+	e.GET("/jobs/submitted", api.JobsSubmittedHandler)
 
 	e.Logger.Fatal(e.Start(":8080"))
 }

--- a/main.go
+++ b/main.go
@@ -2,12 +2,11 @@ package main
 
 import (
 	"github.com/cyverse-de/de-stats/api"
-	"github.com/cyverse-de/echo-middleware/redoc"
 	"github.com/cyverse-de/de-stats/cron"
+	_ "github.com/cyverse-de/de-stats/docs"
+	"github.com/cyverse-de/echo-middleware/redoc"
 	"github.com/labstack/echo"
 	"github.com/labstack/echo/middleware"
-
-	_ "github.com/cyverse-de/de-stats/docs"
 )
 
 func main() {
@@ -21,12 +20,12 @@ func main() {
 
 	e.GET("/", api.RootHandler)
 
-	e.GET("/apps", api.AppsHandler)
-	e.GET("/users", api.UsersHandler)
-	e.GET("/jobs/submitted", api.JobsSubmittedHandler)
-	e.GET("/jobs/status", api.JobsStatusHandler)
-	e.GET("/logins", api.LoginCountHandler)
-	e.GET("/logins/distinct", api.DistinctLoginCountHandler)
+	e.GET("/apps", api.BuildAppsHandler(db))
+	e.GET("/users", api.BuildUsersHandler(db))
+	e.GET("/jobs/submitted", api.BuildJobsSubmittedHandler(db))
+	e.GET("/jobs/status", api.BuildJobsStatusHandler(db))
+	e.GET("/logins", api.BuildLoginCountHandler(db))
+	e.GET("/logins/distinct", api.BuildDistinctLoginCountHandler(db))
 
 	e.Logger.Fatal(e.Start(":8080"))
 }

--- a/main.go
+++ b/main.go
@@ -24,6 +24,7 @@ func main() {
 	e.GET("/apps", api.AppsHandler)
 	e.GET("/users", api.UsersHandler)
 	e.GET("/jobs/submitted", api.JobsSubmittedHandler)
+	e.GET("/jobs/status", api.JobsStatusHandler)
 
 	e.Logger.Fatal(e.Start(":8080"))
 }

--- a/main.go
+++ b/main.go
@@ -26,7 +26,7 @@ func main() {
 	e.GET("/jobs/submitted", api.JobsSubmittedHandler)
 	e.GET("/jobs/status", api.JobsStatusHandler)
 	e.GET("/logins", api.LoginCountHandler)
-	e.GET("/logins/distinct", api.DistinceLoginCountHandler)
+	e.GET("/logins/distinct", api.DistinctLoginCountHandler)
 
 	e.Logger.Fatal(e.Start(":8080"))
 }

--- a/util/query.go
+++ b/util/query.go
@@ -13,6 +13,10 @@ type ErrorResponse struct {
 	Description string `json:"description"`
 }
 
+const (
+	dateFormat = "20060102"
+)
+
 // IntQueryParam extracts the value of an integer query parameter and performs range checking.
 func IntQueryParam(ctx echo.Context, name string, defaultValue, minValue, maxValue int) (int, error) {
 
@@ -48,10 +52,6 @@ func StringQueryParam(ctx echo.Context, name string, defaultValue string) (strin
 }
 
 func VerifyDateParameters(ctx echo.Context) (string, string, error) {
-	const (
-		dateFormat = "20060102"
-	)
-
 	currentTime := time.Now()
 	oneWeekAgo := time.Now().AddDate(0, 0, -7)
 

--- a/util/query.go
+++ b/util/query.go
@@ -2,10 +2,16 @@ package util
 
 import (
 	"fmt"
-	"strconv"
-
 	"github.com/labstack/echo"
+	"net/http"
+	"strconv"
+	"time"
 )
+
+// ErrorResponse describes an error response for any endpoint.
+type ErrorResponse struct {
+	Description string `json:"description"`
+}
 
 // IntQueryParam extracts the value of an integer query parameter and performs range checking.
 func IntQueryParam(ctx echo.Context, name string, defaultValue, minValue, maxValue int) (int, error) {
@@ -39,4 +45,25 @@ func StringQueryParam(ctx echo.Context, name string, defaultValue string) (strin
 	}
 
 	return valueStr, nil
+}
+
+func VerifyDateParameters(ctx echo.Context) (string, string, error) {
+	const (
+		dateFormat = "20060102"
+	)
+
+	currentTime := time.Now()
+	oneWeekAgo := time.Now().AddDate(0, 0, -7)
+
+	startDate, err := StringQueryParam(ctx, "startDate", oneWeekAgo.Format(dateFormat))
+	if err != nil {
+		return "", "", ctx.JSON(http.StatusBadRequest, ErrorResponse{Description: err.Error()})
+	}
+
+	endDate, err := StringQueryParam(ctx, "endDate", currentTime.Format(dateFormat))
+	if err != nil{
+		return "", "", ctx.JSON(http.StatusBadRequest, ErrorResponse{Description: err.Error()})
+	}
+
+	return startDate, endDate, nil
 }

--- a/util/query.go
+++ b/util/query.go
@@ -29,3 +29,14 @@ func IntQueryParam(ctx echo.Context, name string, defaultValue, minValue, maxVal
 
 	return value, nil
 }
+
+func StringQueryParam(ctx echo.Context, name string, defaultValue string) (string, error) {
+
+	// Get the query parameter value.
+	valueStr := ctx.QueryParam(name)
+	if valueStr == "" {
+		return defaultValue, nil
+	}
+
+	return valueStr, nil
+}

--- a/util/query.go
+++ b/util/query.go
@@ -3,7 +3,6 @@ package util
 import (
 	"fmt"
 	"github.com/labstack/echo"
-	"net/http"
 	"strconv"
 	"time"
 )
@@ -57,12 +56,12 @@ func VerifyDateParameters(ctx echo.Context) (string, string, error) {
 
 	startDate, err := StringQueryParam(ctx, "startDate", oneWeekAgo.Format(dateFormat))
 	if err != nil {
-		return "", "", ctx.JSON(http.StatusBadRequest, ErrorResponse{Description: err.Error()})
+		return "", "", err
 	}
 
 	endDate, err := StringQueryParam(ctx, "endDate", currentTime.Format(dateFormat))
 	if err != nil{
-		return "", "", ctx.JSON(http.StatusBadRequest, ErrorResponse{Description: err.Error()})
+		return "", "", err
 	}
 
 	return startDate, endDate, nil


### PR DESCRIPTION
The endpoints added in this PR are as follows:

Param defaults:
StartDate - 1 week ago
EndDate - today
Count - 10

/apps: Returns the top apps and how many times they were used in a given time period.
Params: 
Count - how many apps to return 
StartDate - the start of the time period
EndDate - the end of the time period

/users: Returns the users who ran the most jobs in a given time period
Params: (same as apps)

/jobs/submitted: Returns the number of submitted jobs in the given time period for each job type (DE, OSG, etc.)
Params: 
StartDate
EndDate

/jobs/status: Returns the job count in the given time period for each job type, and what their status was (passed, failed, cancelled).
Params: (same as /jobs/submitted)

/logins: Return the total number of logins in a given time period
Params: (same as /jobs/submitted)

/logins/distinct: Returns the total number of distinct logins in a given time period
Params: (same as /jobs/submitted)